### PR TITLE
iOS 17.1+ 에서 바텀시트가 제대로 표시되지 않는 문제를 해결합니다.

### DIFF
--- a/PanModal/Controller/PanModalPresentationController.swift
+++ b/PanModal/Controller/PanModalPresentationController.swift
@@ -177,6 +177,10 @@ open class PanModalPresentationController: UIPresentationController {
         guard let containerView = containerView
             else { return }
 
+        if self.panContainerView.frame == .zero {
+          self.adjustPresentedViewFrame()
+        }
+
         layoutBackgroundView(in: containerView)
         layoutPresentedView(in: containerView)
         configureScrollViewInsets()


### PR DESCRIPTION
## 배경

- [유원님께서 공유주신 PR](https://github.com/slackhq/PanModal/pull/204) 기반으로 수정했습니다.

## 작업 내용

- PanModalPresentionController 에서 화면 present 가 시작될 때 프레임이 0이면 다시 계산하도록 구성했습니다.

## 리뷰 노트

- 이 부분 제가 이슈 확인할 때 브레이크 포인트 찍어서 프레임이 잘 잡히는 것으로 확인했었는데, 타이밍 관련된 문제가 조금 있었던 것 같습니다 ㅜ 간단한 방법이라 좋네요!
