### PR TITLE
바텀시트 dismiss 콜백 함수에 Dim 영역, 스크롤을 통해 바텀시트를 닫았는지 여부를 반환합니다.

### DIFF
--- a/PanModal/Controller/PanModalPresentationController.swift
+++ b/PanModal/Controller/PanModalPresentationController.swift
@@ -99,6 +99,11 @@ open class PanModalPresentationController: UIPresentationController {
         return presentedViewController as? PanModalPresentable
     }
 
+    /**
+     A Flag is Tap the dimmed background to return whether it is off or on
+     */
+    private var isDismissedForCancel: Bool = false
+
     // MARK: - Views
 
     /**
@@ -113,6 +118,7 @@ open class PanModalPresentationController: UIPresentationController {
         }
         view.didTap = { [weak self] _ in
             if self?.presentable?.allowsTapToDismiss == true {
+                self?.isDismissedForCancel = true
                 self?.presentedViewController.dismiss(animated: true)
             }
         }
@@ -203,7 +209,7 @@ open class PanModalPresentationController: UIPresentationController {
     }
 
     override public func dismissalTransitionWillBegin() {
-        presentable?.panModalWillDismiss()
+        presentable?.panModalWillDismiss(isDismissedForCancel: self.isDismissedForCancel)
 
         guard let coordinator = presentedViewController.transitionCoordinator else {
             backgroundView.dimState = .off
@@ -223,8 +229,7 @@ open class PanModalPresentationController: UIPresentationController {
 
     override public func dismissalTransitionDidEnd(_ completed: Bool) {
         if !completed { return }
-        
-        presentable?.panModalDidDismiss()
+        presentable?.panModalDidDismiss(isDismissedForCancel: self.isDismissedForCancel)
     }
 
     /**
@@ -527,6 +532,7 @@ private extension PanModalPresentationController {
                     transition(to: .shortForm)
 
                 } else {
+                    self.isDismissedForCancel = true
                     presentedViewController.dismiss(animated: true)
                 }
 
@@ -545,6 +551,7 @@ private extension PanModalPresentationController {
                     transition(to: .shortForm)
 
                 } else {
+                    self.isDismissedForCancel = true
                     presentedViewController.dismiss(animated: true)
                 }
             }

--- a/PanModal/Presentable/PanModalPresentable+Defaults.swift
+++ b/PanModal/Presentable/PanModalPresentable+Defaults.swift
@@ -117,11 +117,11 @@ public extension PanModalPresentable where Self: UIViewController {
 
     }
 
-    func panModalWillDismiss() {
+    func panModalWillDismiss(isDismissedForCancel: Bool) {
 
     }
 
-    func panModalDidDismiss() {
+    func panModalDidDismiss(isDismissedForCancel: Bool) {
 
     }
 }

--- a/PanModal/Presentable/PanModalPresentable.swift
+++ b/PanModal/Presentable/PanModalPresentable.swift
@@ -225,13 +225,13 @@ public protocol PanModalPresentable: AnyObject {
 
      Default value is an empty implementation.
      */
-    func panModalWillDismiss()
+    func panModalWillDismiss(isDismissedForCancel: Bool)
 
     /**
      Notifies the delegate after the pan modal is dismissed.
 
      Default value is an empty implementation.
      */
-    func panModalDidDismiss()
+    func panModalDidDismiss(isDismissedForCancel: Bool)
 }
 #endif


### PR DESCRIPTION
## 배경

- 홈 베스트탭 바텀시트를 구현하면서 유저가 직접 BottomSheet 의 Dim 영역이나, 스크롤 인디케이터를 통해 바텀시트를 닫을 경우 dismiss 라는 콜백을 웹으로 반환해야합니다.
- PanModal 상에는 해당 스펙이 존재하지 않아 이를 구현하는 작업을 진행합니다.

## 작업 내용
- 사용자가 Dim 영역을 탭하거나, 스크롤을 통해 바텀시트를 닫는지 여부를 dismiss 콜백 함수에 함께 보내주도록 구현합니다.

## 테스트 방법
- 로그가 정상적으로 찍히는지 확인합니다.

## 리뷰 노트
- 내부에서 세부적으로 액션을 나눌까 했는데 아직은 해당 스펙이 필요하지 않아 일단 Bool 값의 프로퍼티로 전환하도록 구현하였습니다.

## 스크린샷

https://github.com/user-attachments/assets/3611b868-e0b1-4c05-a16b-377b01bcd335



